### PR TITLE
Fix TimeDistributed layer wrapper

### DIFF
--- a/keras_rcnn/models.py
+++ b/keras_rcnn/models.py
@@ -8,16 +8,13 @@ class RCNN(keras.models.Model):
     def __init__(self, inputs, classes, regions_of_interest):
         y = keras_rcnn.layers.ROI(14, regions_of_interest)(inputs)
 
-        y = keras.layers.Dense(4096)(y)
-        y = keras.layers.TimeDistributed(y)
+        y = keras.layers.TimeDistributed(keras.layers.Dense(4096))(y)
 
         score = keras.layers.Dense(classes)(y)
-        score = keras.layers.Activation("softmax")(score)
-        score = keras.layers.TimeDistributed(score)
+        score = keras.layers.TimeDistributed(keras.layers.Activation("softmax"))(score)
 
         boxes = keras.layers.Dense(4 * (classes - 1))(y)
-        boxes = keras.layers.Activation("linear")(boxes)
-        boxes = keras.layers.TimeDistributed(boxes)
+        boxes = keras.layers.TimeDistributed(keras.layers.Activation("linear"))(boxes)
 
         super(RCNN, self).__init__(inputs, [score, boxes])
 


### PR DESCRIPTION
Hi guys, 
thank you all for the great job you're doing, I'm hoping this rcnn implementation will soon be available to all keras users to push the research on detection forward.
Trying to test your code maybe I found a bug in the TimeDistributed implementation, at the moment it seems to have a tensor as an argument but it needs a layer for it to work as it can be seen [here](https://keras.io/getting-started/functional-api-guide/#all-models-are-callable-just-like-layers)
Doing this fixed the Exception that was being raised by keras.

so instead of:

```python
y = keras.layers.Dense(4096)(y)  
y = keras.layers.TimeDistributed(y)
```

I think it needs to be:
```python
y = keras.layers.TimeDistributed(keras.layers.Dense(4096))(y)
```
